### PR TITLE
String regex fix

### DIFF
--- a/jaclparser.py
+++ b/jaclparser.py
@@ -18,7 +18,10 @@ DELIM = ':'
 
 STRING = '"'
 RAW_STRING = 'r"'
-ESCAPEABLE_QUOTE_REGEX = r'(["\'])(?:(?=(\\?))\2.)*?\1'
+
+# taken from https://stackoverflow.com/questions/249791/regex-for-quoted-string-with-escaping-quotes
+# Marc-André Poulin's answer.
+ESCAPEABLE_QUOTE_REGEX = r'"(?:[^"\\]*(?:\\.)?)*"'
 
 BEGIN_COMMENT = '/*'
 END_COMMENT = '*/'
@@ -79,6 +82,10 @@ def parse_float(tok):
     except ValueError:
         return None
 
+
+def replace_escapes(s):
+    return s.replace('\\\"', '\"').replace('\\\\', '\\')
+
 def parse_string(tok, s):
     if tok[0] == STRING:
         s.undo()
@@ -88,11 +95,11 @@ def parse_string(tok, s):
             nextToken(s)
             raise ValueError('broken string!')
         else:
-            return match.replace('\\\"', '\"')[1:-1]
+            return replace_escapes(match)[1:-1]
     elif len(tok) >= 2 and tok[0:2] == RAW_STRING:
         s.undo()
         s.scan(r'r')
-        return s.scan(ESCAPEABLE_QUOTE_REGEX).replace('\\\"', '\"')[1:-1]
+        return replace_escapes(s.scan(ESCAPEABLE_QUOTE_REGEX))[1:-1]
     
     return None
 

--- a/test.jacl
+++ b/test.jacl
@@ -1,6 +1,10 @@
 port : 31415
-data = [{
-    "hello" : 537
-    "there" : 483
-    "my" : 82
+data : [{
+    "we" : 537
+    "have" : 483
+    "cool" : 82
+    r"
+    multiline
+    strings
+    and" : " \"escape\" \" \"sequences \\"
 }]

--- a/test.jacl
+++ b/test.jacl
@@ -4,7 +4,7 @@ data : [{
     "have" : 483
     "cool" : 82
     r"
-    multiline
+    \"multiline\"
     strings
-    and" : " \"escape\" \" \"sequences \\"
+    and\\" : " \"escape\" \" \"sequences \\"
 }]


### PR DESCRIPTION
fixes #2 and #3. Added a new test case to `test.jacl` which covers this:
```
    r"
    \"multiline\"
    strings
    and\\" : " \"escape\" \" \"sequences \\"
```
yeilds the entry:
```
('\n    "multiline"\n    strings\n    and\\', ' "escape" " "sequences \\')
```
note that the `\\` at the end is correct behavior as this is how python displays `\` for strings.
see https://github.com/AmethystGear/JACL/issues/2#issuecomment-686916930 for why I used a different regex than proposed in #2